### PR TITLE
Optimize Segmentation and Depth Postprocessing

### DIFF
--- a/app/src/main/java/com/example/visionapp/onnxmodels/processing/DepthPostprocessor.kt
+++ b/app/src/main/java/com/example/visionapp/onnxmodels/processing/DepthPostprocessor.kt
@@ -2,8 +2,6 @@ package com.example.visionapp.onnxmodels.processing
 
 import android.graphics.Bitmap
 import android.graphics.Color
-import androidx.core.graphics.createBitmap
-import androidx.core.graphics.set
 
 
 class DepthPostprocessor : IPostprocessor<FloatArray, Bitmap?> {
@@ -23,14 +21,17 @@ class DepthPostprocessor : IPostprocessor<FloatArray, Bitmap?> {
         val width = array[0].size
         val height = array.size
         val depthBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-        for (x in 0 until width) {
-            for (y in 0 until height) {
+        val resultPixels = IntArray(width * height)
+
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val index = y * width + x
                 val depthValue = (array[y][x] * 255f).toInt().coerceIn(0, 255)
                 val gray = Color.rgb(depthValue, depthValue, depthValue)
-                depthBitmap.setPixel(x, y, gray)
+                resultPixels[index] = gray
             }
         }
-
+        depthBitmap.setPixels(resultPixels, 0, width, 0, 0, width, height)
         return depthBitmap
     }
 }


### PR DESCRIPTION
Changed current approach. Instead of accessing the bitmap for each pixel, now we calculate a whole array of pixels beforehand and after that we set all the pixels at once.

This spares us around 200ms normally and around 400 ms in debug mode.

Also made a change in depth postprocessing. Here we got only 30ms speed up but that's better than nothing